### PR TITLE
azure-  added postgresql server and database resource

### DIFF
--- a/tools/c7n_azure/c7n_azure/entry.py
+++ b/tools/c7n_azure/c7n_azure/entry.py
@@ -63,9 +63,9 @@ import c7n_azure.resources.apimanagement
 import c7n_azure.resources.appserviceplan
 import c7n_azure.resources.dns_zone
 import c7n_azure.resources.event_hub
-import c7n_azure.resources.record_set  # noqa: F401
+import c7n_azure.resources.record_set
 import c7n_azure.resources.postgresql_server
-import c7n_azure.resources.postgresql_database
+import c7n_azure.resources.postgresql_database  # noqa: F401
 
 
 def initialize_azure():

--- a/tools/c7n_azure/c7n_azure/entry.py
+++ b/tools/c7n_azure/c7n_azure/entry.py
@@ -64,6 +64,8 @@ import c7n_azure.resources.appserviceplan
 import c7n_azure.resources.dns_zone
 import c7n_azure.resources.event_hub
 import c7n_azure.resources.record_set  # noqa: F401
+import c7n_azure.resources.postgresql_server
+import c7n_azure.resources.postgresql_database
 
 
 def initialize_azure():

--- a/tools/c7n_azure/c7n_azure/resources/postgresql_database.py
+++ b/tools/c7n_azure/c7n_azure/resources/postgresql_database.py
@@ -1,0 +1,51 @@
+# Copyright 2018 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from c7n_azure.provider import resources
+from c7n_azure.resources.arm import ChildArmResourceManager
+
+
+@resources.register('postgresqldatabase')
+class PostgresqlDatabase(ChildArmResourceManager):
+    """PostgreSQL Database Resource
+
+    The ``azure.postgresqldatabase`` resource is a child resource of the PostgreSQL Server resource,
+    and the PostgreSQL Server parent id is available as the ``c7n:parent-id`` property.
+
+    :example:
+
+    Finds all PostgreSQL Databases in the subscription.
+
+    .. code-block:: yaml
+
+        policies:
+            - name: find-all-postgresql-databases
+              resource: azure.postgresqldatabase
+    """
+
+    class resource_type(ChildArmResourceManager.resource_type):
+        doc_groups = ['Databases']
+
+        service = 'azure.mgmt.rdbms.postgresql'
+        client = 'PostgreSQLManagementClient'
+        enum_spec = ('databases', 'list_by_server', None)
+        parent_manager_name = 'postgresqlserver'
+        resource_type = 'Microsoft.DBforPostgreSQL/servers/databases'
+
+        enable_tag_operations = False  # GH Issue #4543 
+
+        @classmethod
+        def extra_args(cls, parent_resource):
+            return {'resource_group_name': parent_resource['resourceGroup'],
+                    'server_name': parent_resource['name']}

--- a/tools/c7n_azure/c7n_azure/resources/postgresql_database.py
+++ b/tools/c7n_azure/c7n_azure/resources/postgresql_database.py
@@ -43,7 +43,7 @@ class PostgresqlDatabase(ChildArmResourceManager):
         parent_manager_name = 'postgresqlserver'
         resource_type = 'Microsoft.DBforPostgreSQL/servers/databases'
 
-        enable_tag_operations = False  # GH Issue #4543 
+        enable_tag_operations = False
 
         @classmethod
         def extra_args(cls, parent_resource):

--- a/tools/c7n_azure/c7n_azure/resources/postgresql_database.py
+++ b/tools/c7n_azure/c7n_azure/resources/postgresql_database.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Capital One Services, LLC
+# 2019 Microsoft Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,22 +16,29 @@ from c7n_azure.provider import resources
 from c7n_azure.resources.arm import ChildArmResourceManager
 
 
-@resources.register('postgresqldatabase')
+@resources.register('postgresql-database')
 class PostgresqlDatabase(ChildArmResourceManager):
     """PostgreSQL Database Resource
 
-    The ``azure.postgresqldatabase`` resource is a child resource of the PostgreSQL Server resource,
-    and the PostgreSQL Server parent id is available as the ``c7n:parent-id`` property.
+    The ``azure.postgresql-database`` resource is a child resource of the PostgreSQL Server 
+    resource, and the PostgreSQL Server parent id is available as the ``c7n:parent-id`` property.
 
     :example:
 
-    Finds all PostgreSQL Databases in the subscription.
+    Finds all PostgreSQL Databases that are children of PostgreSQL Servers with the 
+    environment:dev tag
 
     .. code-block:: yaml
 
         policies:
-            - name: find-all-postgresql-databases
-              resource: azure.postgresqldatabase
+          - name: find-all-dev-postgresql-databases
+            resource: azure.postgresql-database
+            filters:
+              - type: parent
+                filter:
+                  type: value
+                  key: tags.environment
+                  value: dev
     """
 
     class resource_type(ChildArmResourceManager.resource_type):
@@ -40,8 +47,13 @@ class PostgresqlDatabase(ChildArmResourceManager):
         service = 'azure.mgmt.rdbms.postgresql'
         client = 'PostgreSQLManagementClient'
         enum_spec = ('databases', 'list_by_server', None)
-        parent_manager_name = 'postgresqlserver'
+        parent_manager_name = 'postgresql-server'
         resource_type = 'Microsoft.DBforPostgreSQL/servers/databases'
+        default_report_fields = (
+            'name',
+            'resourceGroup',
+            '"c7n:parent-id"'
+        )
 
         enable_tag_operations = False
 

--- a/tools/c7n_azure/c7n_azure/resources/postgresql_server.py
+++ b/tools/c7n_azure/c7n_azure/resources/postgresql_server.py
@@ -1,0 +1,45 @@
+# Copyright 2018 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from c7n_azure.provider import resources
+from c7n_azure.resources.arm import ArmResourceManager
+
+
+@resources.register('postgresqlserver')
+class PostgresqlServer(ArmResourceManager):
+    """PostgreSQL Server Resource
+
+    :example:
+
+    Finds all PostgreSQL Servers in the subscription.
+
+    .. code-block:: yaml
+
+        policies:
+            - name: find-all-postgresql-servers
+              resource: azure.postgresqlserver
+    """
+
+    class resource_type(ArmResourceManager.resource_type):
+        doc_groups = ['Databases']
+
+        service = 'azure.mgmt.rdbms.postgresql'
+        client = 'PostgreSQLManagementClient'
+        enum_spec = ('servers', 'list', None)
+        resource_type = 'Microsoft.DBforPostgreSQL/servers'
+        default_report_fields = (
+            'name',
+            'location',
+            'resourceGroup'
+        )

--- a/tools/c7n_azure/c7n_azure/resources/postgresql_server.py
+++ b/tools/c7n_azure/c7n_azure/resources/postgresql_server.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Capital One Services, LLC
+# 2019 Microsoft Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,19 +16,41 @@ from c7n_azure.provider import resources
 from c7n_azure.resources.arm import ArmResourceManager
 
 
-@resources.register('postgresqlserver')
+@resources.register('postgresql-server')
 class PostgresqlServer(ArmResourceManager):
     """PostgreSQL Server Resource
 
     :example:
 
-    Finds all PostgreSQL Servers in the subscription.
+    Finds all PostgreSQL Servers that have had zero active connections in the past week
 
     .. code-block:: yaml
 
         policies:
-            - name: find-all-postgresql-servers
-              resource: azure.postgresqlserver
+          - name: find-all-unused-postgresql-servers
+            resource: azure.postgresql-server
+            filters:
+              - type: metric
+                metric: active_connections
+                op: eq
+                threshold: 0
+                timeframe: 168
+
+    :example:
+
+    Finds all PostgreSQL Servers that cost more than 1000 in the last month
+
+    .. code-block:: yaml
+
+        policies:
+          - name: find-all-costly-postgresql-servers
+            resource: azure.postgresql-server
+            filters:
+              - type: cost
+                key: TheLastMonth
+                op: gt
+                value: 1000
+
     """
 
     class resource_type(ArmResourceManager.resource_type):
@@ -38,8 +60,3 @@ class PostgresqlServer(ArmResourceManager):
         client = 'PostgreSQLManagementClient'
         enum_spec = ('servers', 'list', None)
         resource_type = 'Microsoft.DBforPostgreSQL/servers'
-        default_report_fields = (
-            'name',
-            'location',
-            'resourceGroup'
-        )

--- a/tools/c7n_azure/setup.py
+++ b/tools/c7n_azure/setup.py
@@ -70,6 +70,7 @@ setup(
                       "azure-mgmt-network>=4.0.0",
                       "azure-mgmt-redis",
                       "azure-mgmt-resource==2.1.0",
+                      "azure-mgmt-rdbms",
                       "azure-mgmt-sql",
                       "azure-mgmt-storage",
                       "azure-mgmt-web",

--- a/tools/c7n_azure/tests/cassettes/PostgresqlDatabaseTest.test_find_database_by_name.json
+++ b/tools/c7n_azure/tests/cassettes/PostgresqlDatabaseTest.test_find_database_by_name.json
@@ -1,0 +1,110 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.DBforPostgreSQL/servers?api-version=2017-12-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "date": [
+                        "Tue, 27 Aug 2019 21:23:58 GMT"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "content-length": [
+                        "788"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "sku": {
+                                    "name": "B_Gen5_1",
+                                    "tier": "Basic",
+                                    "family": "Gen5",
+                                    "capacity": 1
+                                },
+                                "properties": {
+                                    "administratorLogin": "custodian",
+                                    "storageProfile": {
+                                        "storageMB": 5120,
+                                        "backupRetentionDays": 7,
+                                        "geoRedundantBackup": "Disabled",
+                                        "storageAutoGrow": "Disabled"
+                                    },
+                                    "version": "10",
+                                    "sslEnforcement": "Enabled",
+                                    "userVisibleState": "Ready",
+                                    "fullyQualifiedDomainName": "cctestpostgresqlservernxmxlpd5w73ag.postgres.database.azure.com",
+                                    "earliestRestoreDate": "2019-08-27T21:24:18.857+00:00",
+                                    "replicationRole": "",
+                                    "masterServerId": ""
+                                },
+                                "location": "westus2",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_postgresql/providers/Microsoft.DBforPostgreSQL/servers/cctestpostgresqlservernxmxlpd5w73ag",
+                                "name": "cctestpostgresqlservernxmxlpd5w73ag",
+                                "type": "Microsoft.DBforPostgreSQL/servers"
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_postgresql/providers/Microsoft.DBforPostgreSQL/servers/cctestpostgresqlservernxmxlpd5w73ag/databases?api-version=2017-12-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "date": [
+                        "Tue, 27 Aug 2019 21:23:59 GMT"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "content-length": [
+                        "1371"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "properties": {
+                                    "charset": "UTF8",
+                                    "collation": "English_United States.1252"
+                                },
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_postgresql/providers/Microsoft.DBforPostgreSQL/servers/cctestpostgresqlservernxmxlpd5w73ag/databases/cctestdb",
+                                "name": "cctestdb",
+                                "type": "Microsoft.DBforPostgreSQL/servers/databases"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests/cassettes/PostgresqlDatabaseTest.test_find_database_by_name.json
+++ b/tools/c7n_azure/tests/cassettes/PostgresqlDatabaseTest.test_find_database_by_name.json
@@ -14,17 +14,17 @@
                     "message": "OK"
                 },
                 "headers": {
-                    "date": [
-                        "Tue, 27 Aug 2019 21:23:58 GMT"
-                    ],
                     "cache-control": [
                         "no-cache"
+                    ],
+                    "date": [
+                        "Thu, 29 Aug 2019 04:32:46 GMT"
                     ],
                     "content-type": [
                         "application/json; charset=utf-8"
                     ],
                     "content-length": [
-                        "788"
+                        "898"
                     ]
                 },
                 "body": {
@@ -49,11 +49,11 @@
                                     "sslEnforcement": "Enabled",
                                     "userVisibleState": "Ready",
                                     "fullyQualifiedDomainName": "cctestpostgresqlservernxmxlpd5w73ag.postgres.database.azure.com",
-                                    "earliestRestoreDate": "2019-08-27T21:24:18.857+00:00",
+                                    "earliestRestoreDate": "2019-08-28T17:55:28.257+00:00",
                                     "replicationRole": "",
                                     "masterServerId": ""
                                 },
-                                "location": "westus2",
+                                "location": "southcentralus",
                                 "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_postgresql/providers/Microsoft.DBforPostgreSQL/servers/cctestpostgresqlservernxmxlpd5w73ag",
                                 "name": "cctestpostgresqlservernxmxlpd5w73ag",
                                 "type": "Microsoft.DBforPostgreSQL/servers"
@@ -76,11 +76,11 @@
                     "message": "OK"
                 },
                 "headers": {
-                    "date": [
-                        "Tue, 27 Aug 2019 21:23:59 GMT"
-                    ],
                     "cache-control": [
                         "no-cache"
+                    ],
+                    "date": [
+                        "Thu, 29 Aug 2019 04:32:46 GMT"
                     ],
                     "content-type": [
                         "application/json; charset=utf-8"

--- a/tools/c7n_azure/tests/cassettes/PostgresqlServerTest.test_find_server_by_name.json
+++ b/tools/c7n_azure/tests/cassettes/PostgresqlServerTest.test_find_server_by_name.json
@@ -14,17 +14,17 @@
                     "message": "OK"
                 },
                 "headers": {
-                    "date": [
-                        "Tue, 27 Aug 2019 21:24:19 GMT"
-                    ],
                     "content-type": [
                         "application/json; charset=utf-8"
                     ],
                     "cache-control": [
                         "no-cache"
                     ],
+                    "date": [
+                        "Thu, 29 Aug 2019 04:32:52 GMT"
+                    ],
                     "content-length": [
-                        "788"
+                        "898"
                     ]
                 },
                 "body": {
@@ -46,14 +46,14 @@
                                         "storageAutoGrow": "Disabled"
                                     },
                                     "version": "10",
-                                    "sslEnforcement": "Enabled",
+                                    "sslEnforcement": "Disabled",
                                     "userVisibleState": "Ready",
                                     "fullyQualifiedDomainName": "cctestpostgresqlservernxmxlpd5w73ag.postgres.database.azure.com",
-                                    "earliestRestoreDate": "2019-08-27T21:24:18.857+00:00",
+                                    "earliestRestoreDate": "2019-08-28T17:55:28.257+00:00",
                                     "replicationRole": "",
                                     "masterServerId": ""
                                 },
-                                "location": "westus2",
+                                "location": "southcentralus",
                                 "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_postgresql/providers/Microsoft.DBforPostgreSQL/servers/cctestpostgresqlservernxmxlpd5w73ag",
                                 "name": "cctestpostgresqlservernxmxlpd5w73ag",
                                 "type": "Microsoft.DBforPostgreSQL/servers"

--- a/tools/c7n_azure/tests/cassettes/PostgresqlServerTest.test_find_server_by_name.json
+++ b/tools/c7n_azure/tests/cassettes/PostgresqlServerTest.test_find_server_by_name.json
@@ -1,0 +1,67 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.DBforPostgreSQL/servers?api-version=2017-12-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "date": [
+                        "Tue, 27 Aug 2019 21:24:19 GMT"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-length": [
+                        "788"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "sku": {
+                                    "name": "B_Gen5_1",
+                                    "tier": "Basic",
+                                    "family": "Gen5",
+                                    "capacity": 1
+                                },
+                                "properties": {
+                                    "administratorLogin": "custodian",
+                                    "storageProfile": {
+                                        "storageMB": 5120,
+                                        "backupRetentionDays": 7,
+                                        "geoRedundantBackup": "Disabled",
+                                        "storageAutoGrow": "Disabled"
+                                    },
+                                    "version": "10",
+                                    "sslEnforcement": "Enabled",
+                                    "userVisibleState": "Ready",
+                                    "fullyQualifiedDomainName": "cctestpostgresqlservernxmxlpd5w73ag.postgres.database.azure.com",
+                                    "earliestRestoreDate": "2019-08-27T21:24:18.857+00:00",
+                                    "replicationRole": "",
+                                    "masterServerId": ""
+                                },
+                                "location": "westus2",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_postgresql/providers/Microsoft.DBforPostgreSQL/servers/cctestpostgresqlservernxmxlpd5w73ag",
+                                "name": "cctestpostgresqlservernxmxlpd5w73ag",
+                                "type": "Microsoft.DBforPostgreSQL/servers"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests/templates/postgresql.json
+++ b/tools/c7n_azure/tests/templates/postgresql.json
@@ -12,7 +12,7 @@
         {
             "apiVersion": "2017-12-01",
             "type": "Microsoft.DBforPostgreSQL/servers",
-            "location": "westus2",
+            "location": "[resourceGroup().location]",
             "name": "[parameters('serverName')]",
             "properties": {
                 "version": "10",

--- a/tools/c7n_azure/tests/templates/postgresql.json
+++ b/tools/c7n_azure/tests/templates/postgresql.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "serverName": {
+            "defaultValue": "[concat('cctestpostgresqlserver', uniqueString(resourceGroup().id))]",
+            "type": "string"
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "apiVersion": "2017-12-01",
+            "type": "Microsoft.DBforPostgreSQL/servers",
+            "location": "westus2",
+            "name": "[parameters('serverName')]",
+            "properties": {
+                "version": "10",
+                "administratorLogin": "custodian",
+                "administratorLoginPassword": "Cust0dianPassw0rd",
+                "createMode": "Default"
+            },
+            "resources": [
+                {
+                    "name": "[concat(parameters('serverName'), '/cctestdb')]",
+                    "type": "Microsoft.DBforPostgreSQL/servers/databases",
+                    "apiVersion": "2017-12-01",
+                    "properties": {},
+                    "dependsOn": [
+                        "[concat('Microsoft.DBforPostgreSQL/servers/', parameters('serverName'))]"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tools/c7n_azure/tests/test_postgresql_database.py
+++ b/tools/c7n_azure/tests/test_postgresql_database.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2018 Capital One Services, LLC
+# 2019 Microsoft Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,18 +19,17 @@ from azure_common import BaseTest, arm_template
 class PostgresqlDatabaseTest(BaseTest):
 
     def test_postgresql_database_schema_validate(self):
-        with self.sign_out_patch():
-            p = self.load_policy({
-                'name': 'test-postgresql-database-schema-validate',
-                'resource': 'azure.postgresqldatabase'
-            }, validate=True)
-            self.assertTrue(p)
+        p = self.load_policy({
+            'name': 'test-postgresql-database-schema-validate',
+            'resource': 'azure.postgresql-database'
+        }, validate=True)
+        self.assertTrue(p)
 
     @arm_template('postgresql.json')
     def test_find_database_by_name(self):
         p = self.load_policy({
             'name': 'test-get-database-by-name',
-            'resource': 'azure.postgresqldatabase',
+            'resource': 'azure.postgresql-database',
             'filters': [
                 {
                     'type': 'value',
@@ -43,4 +42,3 @@ class PostgresqlDatabaseTest(BaseTest):
 
         resources = p.run()
         self.assertEqual(len(resources), 1)
-        self.assertEqual(resources[0]['name'], 'cctestdb')

--- a/tools/c7n_azure/tests/test_postgresql_database.py
+++ b/tools/c7n_azure/tests/test_postgresql_database.py
@@ -1,0 +1,46 @@
+# Copyright 2015-2018 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+from azure_common import BaseTest, arm_template
+
+
+class PostgresqlDatabaseTest(BaseTest):
+
+    def test_postgresql_database_schema_validate(self):
+        with self.sign_out_patch():
+            p = self.load_policy({
+                'name': 'test-postgresql-database-schema-validate',
+                'resource': 'azure.postgresqldatabase'
+            }, validate=True)
+            self.assertTrue(p)
+
+    @arm_template('postgresql.json')
+    def test_find_database_by_name(self):
+        p = self.load_policy({
+            'name': 'test-get-database-by-name',
+            'resource': 'azure.postgresqldatabase',
+            'filters': [
+                {
+                    'type': 'value',
+                    'key': 'name',
+                    'op': 'eq',
+                    'value': 'cctestdb'
+                }
+            ]
+        })
+
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['name'], 'cctestdb')

--- a/tools/c7n_azure/tests/test_postgresql_server.py
+++ b/tools/c7n_azure/tests/test_postgresql_server.py
@@ -1,0 +1,46 @@
+# Copyright 2015-2018 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+from azure_common import BaseTest, arm_template
+
+
+class PostgresqlServerTest(BaseTest):
+
+    def test_postgresql_server_schema_validate(self):
+        with self.sign_out_patch():
+            p = self.load_policy({
+                'name': 'test-postgresql-server-schema-validate',
+                'resource': 'azure.postgresqlserver'
+            }, validate=True)
+            self.assertTrue(p)
+
+    @arm_template('postgresql.json')
+    def test_find_server_by_name(self):
+        p = self.load_policy({
+            'name': 'test-azure-postgresql-server',
+            'resource': 'azure.postgresqlserver',
+            'filters': [
+                {
+                    'type': 'value',
+                    'key': 'name',
+                    'op': 'glob',
+                    'value_type': 'normalize',
+                    'value': 'cctestpostgresqlserver*'
+                }
+            ],
+        })
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertTrue(resources[0]['name'].startswith('cctestpostgresqlserver'))

--- a/tools/c7n_azure/tests/test_postgresql_server.py
+++ b/tools/c7n_azure/tests/test_postgresql_server.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2018 Capital One Services, LLC
+# 2019 Microsoft Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,18 +19,17 @@ from azure_common import BaseTest, arm_template
 class PostgresqlServerTest(BaseTest):
 
     def test_postgresql_server_schema_validate(self):
-        with self.sign_out_patch():
-            p = self.load_policy({
-                'name': 'test-postgresql-server-schema-validate',
-                'resource': 'azure.postgresqlserver'
-            }, validate=True)
-            self.assertTrue(p)
+        p = self.load_policy({
+            'name': 'test-postgresql-server-schema-validate',
+            'resource': 'azure.postgresql-server'
+        }, validate=True)
+        self.assertTrue(p)
 
     @arm_template('postgresql.json')
     def test_find_server_by_name(self):
         p = self.load_policy({
             'name': 'test-azure-postgresql-server',
-            'resource': 'azure.postgresqlserver',
+            'resource': 'azure.postgresql-server',
             'filters': [
                 {
                     'type': 'value',
@@ -43,4 +42,3 @@ class PostgresqlServerTest(BaseTest):
         })
         resources = p.run()
         self.assertEqual(len(resources), 1)
-        self.assertTrue(resources[0]['name'].startswith('cctestpostgresqlserver'))


### PR DESCRIPTION
Added PostgreSQL Server & PostgreSQL Database resource support. The PostgreSQL database resource is a child resource to the PostgreSQL server resource. Addresses [issue](https://github.com/cloud-custodian/cloud-custodian/issues/3339)

ex. 

    Finds all PostgreSQL Servers in the subscription.

        policies:
            - name: find-all-postgresql-servers
              resource: azure.postgresql-server

ex. 

    Finds all PostgreSQL Databases in the subscription.

        policies:
            - name: find-all-postgresql-databases
              resource: azure.postgresql-database