### PR TITLE
azure - action - set-public-access functionality for blob storage containers

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/storage_container.py
+++ b/tools/c7n_azure/c7n_azure/resources/storage_container.py
@@ -14,6 +14,9 @@
 
 from c7n_azure.provider import resources
 from c7n_azure.query import ChildTypeInfo, ChildResourceManager
+from c7n_azure.actions.base import AzureBaseAction
+from c7n.filters.core import type_schema
+from c7n_azure.utils import ResourceIdParser
 
 
 @resources.register('storage-container')
@@ -52,3 +55,54 @@ class StorageContainer(ChildResourceManager):
         def extra_args(cls, parent_resource):
             return {'resource_group_name': parent_resource['resourceGroup'],
                     'account_name': parent_resource['name']}
+
+
+@StorageContainer.action_registry.register('set-public-access')
+class StorageContainerSetPublicAccessAction(AzureBaseAction):
+    """Action that updates the access level setting on Storage Containers.
+    Programmatically, this will be seen by updating the Public Access setting
+
+    :example:
+
+       Turns on Secure transfer required for all storage accounts. This will reject requests that
+       use HTTP to your storage accounts.
+
+       Turns off public access for all Blob Storage Containers that are not in Storage Accounts with
+       an "environment:production" tag.
+
+    .. code-block:: yaml
+
+        policies:
+            - name: set-non-production-accounts-private
+              resource: azure.storage-container
+              filters:
+                - type: parent
+                  filter:
+                    type: value
+                    key: tags.environment
+                    op: ne
+                    value: production
+              actions:
+              - type: set-public-access
+                value: None
+    """
+    schema = type_schema(
+        'set-public-access',
+        **{
+            'value': {'enum': ['Container', 'Blob', 'None'], "default": 'None'},
+        }
+    )
+
+    def _prepare_processing(self):
+        self.client = self.manager.get_client()
+
+    def _process_resource(self, resource):
+        resource_group = ResourceIdParser.get_resource_group(resource['id'])
+        account_name = ResourceIdParser.get_resource_name(resource['c7n:parent-id'])
+
+        self.client.blob_containers.update(
+            resource_group,
+            account_name,
+            resource['name'],
+            public_access=self.data.get('value')
+        )

--- a/tools/c7n_azure/c7n_azure/resources/storage_container.py
+++ b/tools/c7n_azure/c7n_azure/resources/storage_container.py
@@ -64,11 +64,7 @@ class StorageContainerSetPublicAccessAction(AzureBaseAction):
 
     :example:
 
-       Turns on Secure transfer required for all storage accounts. This will reject requests that
-       use HTTP to your storage accounts.
-
-       Turns off public access for all Blob Storage Containers that are not in Storage Accounts with
-       an "environment:production" tag.
+       Finds all Blob Storage Containers that are not private and sets them to private
 
     .. code-block:: yaml
 
@@ -76,15 +72,13 @@ class StorageContainerSetPublicAccessAction(AzureBaseAction):
             - name: set-non-production-accounts-private
               resource: azure.storage-container
               filters:
-                - type: parent
-                  filter:
-                    type: value
-                    key: tags.environment
-                    op: ne
-                    value: production
+                - type: value
+                  key: properties.publicAccess
+                  op: not-equal
+                  value: None
               actions:
-              - type: set-public-access
-                value: None
+                - type: set-public-access
+                  value: None
     """
     schema = type_schema(
         'set-public-access',

--- a/tools/c7n_azure/tests/test_storage_container.py
+++ b/tools/c7n_azure/tests/test_storage_container.py
@@ -15,6 +15,9 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from azure_common import BaseTest, arm_template, cassette_name
 from c7n_azure.storage_utils import StorageUtilities
+from mock import patch
+from c7n_azure.session import Session
+from c7n_azure.utils import local_session
 
 
 class StorageContainerTest(BaseTest):
@@ -47,3 +50,39 @@ class StorageContainerTest(BaseTest):
         resources = p.run()
         self.assertEqual(2, len(resources))
         self.assertEqual({'containerone', 'containertwo'}, set([c['name'] for c in resources]))
+
+    @arm_template('storage.json')
+    @cassette_name('containers')
+    @patch('azure.mgmt.storage.v2019_04_01.operations.BlobContainersOperations.update')
+    def test_set_public_access(self, update_container_mock):
+        with patch('azure.mgmt.storage.v%s.operations.'
+        'BlobContainersOperations.update'
+        % self._get_storage_management_client_api_string()) as update_container_mock:
+            p = self.load_policy({
+                'name': 'test-azure-storage-container-enum',
+                'resource': 'azure.storage-container',
+                'filters': [
+                    {
+                        'type': 'value',
+                        'key': 'name',
+                        'value': 'containerone'
+                    }
+                ],
+                'actions': [
+                    {
+                        'type': 'set-public-access',
+                        'value': 'None'
+                    }
+                ]
+            }, validate=True)
+
+            p.run()
+            args, kwargs = update_container_mock.call_args_list[0]
+            self.assertEqual('test_storage', args[0])
+            self.assertTrue(args[1].startswith('cctstorage'))
+            self.assertEqual(None, kwargs['public_access'])
+
+    def _get_storage_management_client_api_string(self):
+        return local_session(Session)\
+            .client('azure.mgmt.storage.StorageManagementClient')\
+            .DEFAULT_API_VERSION.replace("-", "_")


### PR DESCRIPTION
Action that allows the user to set the public access setting for blob storage containers. This addresses [Issue #4737](https://github.com/cloud-custodian/cloud-custodian/issues/4737)

`get_storage_management_client_api_string` is used because mocking the update call is dependent on the API version. The same is done in `tools/c7n_azure/tests/test_storage.py`. The function could possibly be put into a utility, such as azure_common. 
